### PR TITLE
Added addtional media:content for thumbnails

### DIFF
--- a/app/views/index/rss.phtml
+++ b/app/views/index/rss.phtml
@@ -49,6 +49,14 @@ foreach ($this->entries as $item) {
 						. (empty($thumbnail['height']) ? '' : '" height="' . $thumbnail['height'])
 						. (empty($thumbnail['time']) ? '' : '" time="' . $thumbnail['time'])
 						. '" />', "\n";
+					/*  Added mostly for MailChimp + Feedbro which don't support <media:thumbnail> 
+						different to media actually inside enclosures below. 
+						See https://mailchimp.com/help/rss-merge-tags/
+					*/
+					  echo "\t\t\t", '<media:content medium="image" url="' . $thumbnail['url']
+						. (empty($thumbnail['width']) ? '' : '" width="' . $thumbnail['width'])
+						. (empty($thumbnail['height']) ? '' : '" height="' . $thumbnail['height'])
+						. '" />', "\n";
 				}
 				$enclosures = $item->enclosures(false);
 				if (is_iterable($enclosures)) {


### PR DESCRIPTION
Closes #5925

Changes proposed in this pull request:

Add media:content to support more RSS readers/services

How to test the feature manually:

1. Provide source which has a thumbnail or image that is NOT in an enclosure, e.g. from XPATH scraping
2. Read RSS in Feedbro or MailChimp (known examples, probably others)
3. Feedbro: note "View enclosure" link for the related image. 
4. MailChimp: note images now appear in RSS created stories. 
5. Also tested with Newsblur and Feedly. 

Pull request checklist:

- [X] clear commit messages
- [X] code manually tested
